### PR TITLE
Add kernel patch for 4.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ In particular, we modify the *generic_make_request_checks* function and insert t
 ## How to install
 Apply the patch to the source code of your kernel and recompile it.
 
-*The patch was originally written for Linux 3.15.1, but it remains compatible with some newer versions of Linux. Additionally, the new version for Linux 4.10 is available.*
+*The patch was originally written for Linux 3.15.1, but it remains compatible with some newer versions of Linux. Updated versions for 4.10 and 4.14 are included as well.
 
 ## How to use
 Simply run the following command: _blockdev --setro /dev/sdb*_ (assuming */dev/sdb* is the evidence to be write protected).

--- a/kernel/linux-4.14-enforce-ro.patch
+++ b/kernel/linux-4.14-enforce-ro.patch
@@ -1,0 +1,22 @@
+--- linux-master/block/blk-core.c	2016-12-16 22:23:34.000000000 +0300
++++ linux-master-patched/block/blk-core.c	2016-12-18 15:12:54.837220465 +0300
+@@ -1903,6 +1903,19 @@ generic_make_request_checks(struct bio *
+ 		}
+ 	}
+ 
++	/*
++	 * Block write, discard, erase, flush, zone reset commands going to a
++	 * read-only device. We do this because kernel drivers often lack
++	 * necessary checks and send these commands to read-only block devices.
++	 */
++	if (unlikely((bio_op(bio) != REQ_OP_READ)
++			&& (bio_op(bio) != REQ_OP_ZONE_REPORT)
++			&& get_disk_ro(bio->bi_disk))) {
++		pr_warn("unexpected write command to %s blocked\n",
++			bio_devname(bio, b));
++		goto end_io;
++	}
++
+ 	switch (bio_op(bio)) {
+ 	case REQ_OP_DISCARD:
+ 		if (!blk_queue_discard(q))


### PR DESCRIPTION
4.14 changed bdev semantics significantly with genhd, include new
kernel patch addressing these changes, update readme.

Todo: update the test forensic test client with the same changes,
either in #ifdefs based on kernel API or as a separate client.